### PR TITLE
Helm Chart for AWS Fargate provider

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+appVersion: "0.11.1"
+description: A Helm chart to install virtual kubelet for AWS fargate
+name: virtual-kubelet-aws-fargate
+sources: 
+  - https://github.com/virtual-kubelet/aws-fargate
+version: 0.1.0
+maintainers:
+  - name: Sumit Joshi
+    email: sumitjoshi024@gmail.com

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,14 @@
+
+Run the following to deploy the chart with rquired settings (Replace the values)
+
+```bash
+helm install --name virtual-kubelet \
+--namespace vk-aws \
+--set aws.region=us-east-1 \
+--set aws.clusterName=ecs-cluster \
+--set aws.subnets[0]="subnet-05d3164d0ab1c734f" \
+--set aws.subnets[1]="subnet-054d7d5e3941b99b3" \
+--set aws.securityGroups[0]="sg-02ea90a0fb77f5cd4" \
+--set nodename=vk-node2
+```
+

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,6 @@
+The virtual kubelet is getting deployed on your cluster.
+
+To verify that virtual kubelet has started, run:
+
+kubectl --namespace={{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "virtual-kubelet-aws-fargate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "virtual-kubelet-aws-fargate.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "virtual-kubelet-aws-fargate.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "virtual-kubelet-aws-fargate.labels" -}}
+app.kubernetes.io/name: {{ include "virtual-kubelet-aws-fargate.name" . }}
+helm.sh/chart: {{ include "virtual-kubelet-aws-fargate.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}                           

--- a/charts/templates/clusterrolebinding.yaml
+++ b/charts/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "virtual-kubelet-aws-fargate.fullname" . }}
+  labels:
+{{ include "virtual-kubelet-aws-fargate.labels" . | indent 4 }}
+subjects:
+-  kind: ServiceAccount
+   name: {{ include "virtual-kubelet-aws-fargate.fullname" . }}
+   namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "virtual-kubelet-aws-fargate.fullname" . }}
+  labels:
+{{ include "virtual-kubelet-aws-fargate.labels" . | indent 4 }}
+data:
+  fargate.toml: |
+    #
+    # Example configuration file for AWS Fargate virtual-kubelet provider.
+    #
+    # Usage:
+    # virtual-kubelet --provider aws --provider-config fargate.toml
+    #
+
+    # AWS region where Fargate resources are provisioned. Mandatory.
+    Region = "{{ .Values.aws.region  }}"
+
+    # AWS Fargate cluster name. Optional. Defaults to "default".
+    # If a cluster with this name does not exist in the region, virtual-kubelet will create it.
+    # Creating a dedicated Fargate cluster for each virtual-kubelet is recommended.
+    ClusterName = "{{ .Values.aws.clusterName  }}"
+
+    # List of subnets that pod ENIs are connected to. Mandatory.
+    Subnets = [
+      {{- range .Values.aws.subnets  }}
+      {{. | quote }},
+      {{- end }}
+      ]
+    # List of security groups associated with pod ENIs. Optional.
+    # If omitted, pod ENIs inherit their VPC's default security group.
+    SecurityGroups = [
+      {{- range .Values.aws.securityGroups }}
+      {{. | quote }},
+      {{- end }}
+      ]
+    # Whether pod ENIs are assigned a public IPv4 address. Optional. Defaults to false.
+    # If your pod requires internet access (e.g. to download container images from ECR or Docker Hub),
+    # this should be set to "true" for pods on public subnets with internet gateways,
+    # and to "false" for pods on private subnets with NAT gateways.
+    AssignPublicIPv4Address = {{ .Values.aws.assignPublicIPv4Address }}
+
+    # Role assumed by AWS Fargate to execute your pod. Optional.
+    # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
+    ExecutionRoleArn = "{{ .Values.aws.taskExecutionRoleARN }}"
+
+    # Amazon CloudWatch log group name used to store container logs. Optional.
+    # If omitted, container logs will not be available.
+    # If specified, an execution role with access to CloudWatch logs is required.
+    CloudWatchLogGroupName = "{{ .Values.aws.cloudWatchLogGroupName }}"
+
+    # AWS Fargate platform version. Optional. Defaults to "LATEST".
+    # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
+    PlatformVersion = "{{ .Values.aws.platformVersion }}"
+
+    # Operating system for pods. Optional. Defaults to "Linux".
+    OperatingSystem = "Linux"
+
+    # AWS Fargate capacity advertised by virtual-kubelet. Optional. Defaults to the values below.
+    # Capacity is specified using Kubernetes resource format.
+    # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    CPU = "20"
+    Memory = "40Gi"
+    Pods = "20"

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "virtual-kubelet-aws-fargate.fullname" . }}
+  labels:
+{{ include "virtual-kubelet-aws-fargate.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "virtual-kubelet-aws-fargate.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: {{ include "virtual-kubelet-aws-fargate.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        args:
+        - --provider
+        - aws
+        - --provider-config
+        - /etc/fargate/fargate.toml
+        - --os 
+        - {{ .Values.os }}
+        - --nodename
+        - {{ .Values.nodename }}
+        command:
+        - virtual-kubelet
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+{{- toYaml .Values.resources | nindent 12 }}
+        env:
+        - name: KUBELET_PORT
+          value: "10250"
+        volumeMounts:
+        - mountPath: /etc/fargate/
+          name: fargate-config-volume
+          readOnly: true
+      serviceAccountName: {{ include "virtual-kubelet-aws-fargate.fullname" . }}
+      volumes:
+      - configMap:
+          items:
+          - key: fargate.toml
+            path: fargate.toml
+          name: {{ include "virtual-kubelet-aws-fargate.fullname" . }}
+        name: fargate-config-volume
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/templates/serviceaccount.yaml
+++ b/charts/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "virtual-kubelet-aws-fargate.fullname" . }}
+  labels: 
+{{ include "virtual-kubelet-aws-fargate.labels" . | indent 4 }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,37 @@
+# Default values for virtual-kubelet-aws-fargate.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: microsoft/virtual-kubelet
+  tag: latest
+  pullPolicy: IfNotPresent
+
+aws:
+  region: us-east-1
+  clusterName: "default-vk"
+  subnets: []
+  securityGroups: []
+  assignPublicIPv4Address: false
+  taskExecutionRoleARN: ""
+  cloudWatchLogGroupName: ""
+  platformVersion: "LATEST"
+
+os: "Linux"
+nodename: "virtual-kubelet"
+  
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Helm Chart for installing virtual-kubelet for AWS Fargate.

- Currently, using same docker image: `microsoft/virtual-kubelet` as in upstream, until fargate specific image is available.
- Using ConfigMap for storing `fargate.toml` file.