### PR TITLE
Remove pod struct in logs

### DIFF
--- a/fargate/pod.go
+++ b/fargate/pod.go
@@ -127,11 +127,12 @@ func NewPod(cluster *Cluster, pod *corev1.Pod) (*Pod, error) {
 	// Register the task definition with Fargate.
 	log.Printf("RegisterTaskDefinition input:%+v", taskDef)
 	output, err := api.RegisterTaskDefinition(taskDef)
-	log.Printf("RegisterTaskDefinition err:%+v output:%+v", err, output)
 	if err != nil {
 		err = fmt.Errorf("failed to register task definition: %v", err)
 		return nil, err
 	}
+
+	log.Printf("RegisterTaskDefinition output:%+v", output)
 
 	// Save the registered task definition ARN.
 	fgPod.taskDefArn = *output.TaskDefinition.TaskDefinitionArn
@@ -193,7 +194,6 @@ func (pod *Pod) Start() error {
 
 	log.Printf("RunTask input:%+v", runTaskInput)
 	runTaskOutput, err := api.RunTask(runTaskInput)
-	log.Printf("RunTask err:%+v output:%+v", err, runTaskOutput)
 	if err != nil || len(runTaskOutput.Tasks) == 0 {
 		if len(runTaskOutput.Failures) != 0 {
 			err = fmt.Errorf("reason: %s", *runTaskOutput.Failures[0].Reason)
@@ -202,6 +202,7 @@ func (pod *Pod) Start() error {
 		return err
 	}
 
+	log.Printf("RunTask output:%+v", runTaskOutput)
 	// Save the task ARN.
 	pod.taskArn = *runTaskOutput.Tasks[0].TaskArn
 

--- a/provider.go
+++ b/provider.go
@@ -166,8 +166,6 @@ func (p *FargateProvider) GetPod(ctx context.Context, namespace, name string) (*
 		return nil, err
 	}
 
-	log.Printf("Responding to GetPod: %+v.\n", spec)
-
 	return spec, nil
 }
 
@@ -216,6 +214,7 @@ func (p *FargateProvider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 	}
 
 	var result []*corev1.Pod
+	var podNames []string
 
 	for _, pod := range pods {
 		spec, err := pod.GetSpec()
@@ -225,9 +224,10 @@ func (p *FargateProvider) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
 		}
 
 		result = append(result, spec)
+		podNames = append(podNames, fmt.Sprintf("%s/%s", spec.Namespace, spec.Name))
 	}
 
-	log.Printf("Responding to GetPods: %+v.\n", result)
+	log.Printf("Responding to GetPods: %+v.\n", podNames)
 
 	return result, nil
 }


### PR DESCRIPTION
Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

Address #12 

1. Do not print pod struct in every pod sync loop
2. Do not print <nil> error, this should be catched in error check. only print output after error handling.
3. Print <namespace/name> in GetPods request when VK provider starts.